### PR TITLE
Rename `boundActionCreators` to `actions`

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,7 @@
 const path = require("path")
 
-exports.onCreateNode = ({node, getNode, boundActionCreators}) => {
-  const {createNodeField} = boundActionCreators
+exports.onCreateNode = ({node, getNode, actions}) => {
+  const {createNodeField} = actions
   const fileNode = getNode(node.parent)
 
   if (


### PR DESCRIPTION
`boundActionCreators` has been deprecated from the past versions of Gatsby. 
In v3, it was removed; However they kept the same behaviour for `actions`

[Migrating from v2 to v3](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#removal-of-boundactioncreators)

I tested in my local Gatsby project and it works as it did before I updated to v3

closes #11 